### PR TITLE
Add BlocksGame to Categories field in .desktop file

### DIFF
--- a/net.stabyourself.nottetris2.desktop
+++ b/net.stabyourself.nottetris2.desktop
@@ -3,4 +3,4 @@ Name=Not Tetris 2
 Exec=/app/bin/nottetris2.sh
 Type=Application
 Icon=net.stabyourself.nottetris2
-Categories=Game
+Categories=Game;BlocksGame


### PR DESCRIPTION
The XDG Menu Spec has a set of [Additional Categories](https://specifications.freedesktop.org/menu-spec/latest/apas02.html) that can be applied to each primary category, which allow launcher menus to automatically do things like grouping games into genres.

Despite it seeming a bit over-specific, there's a spec-defined category for falling block games, so let's use it.