### PR TITLE
update runtime to 22.08

### DIFF
--- a/net.stabyourself.nottetris2.yml
+++ b/net.stabyourself.nottetris2.yml
@@ -1,6 +1,6 @@
 id: net.stabyourself.nottetris2
 runtime: org.freedesktop.Platform
-runtime-version: "20.08"
+runtime-version: "22.08"
 sdk: org.freedesktop.Sdk
 command: /app/bin/nottetris2.sh
 finish-args:


### PR DESCRIPTION
A single character change to update runtime to 22.08. Build worked on my system, and I didn't have any problems playing the game.